### PR TITLE
Added "DELETE_WORDS" and "MONO" config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This is a Python script to organize and convert your samples for the M8 tracker.
 
 **[Watch a video on how to use this tool](https://www.youtube.com/watch?v=VI0IuEDY8HI).**
 
-# M8 Sample Organizer
+# M8 Sample Organizer updates 7/2/2025 to make it more useful for the PicoTracker
+
 
 The [M8 is a delightful, gameboy-shaped sampler, sequencer and synthesizer](https://dirtywave.com/).
 
@@ -35,6 +36,8 @@ It does lots of cleanup:
 * **Removes** duplicate words, punctuation and common filler phrases (like `processed` and `final`)
 * **Simplifies** layers of folders into one level
 * **Detects** new files added to your library each time you run it
+
+The PicoTracker is a simpler (and cheaper!) tracker very similar to the M8 - they are both based on the LSDJ tracker. The PicoTracker has a filename limit of 24 characters which may require some "aggressive" trimming of filenames. The "DELETE_WORDS" config option has been added for this. "MONO" config option added for mono output which loads much faster on the PicoTracker.
 
 # Instructions
 

--- a/config.yml-Picotracker example
+++ b/config.yml-Picotracker example
@@ -1,0 +1,118 @@
+### M8 Sample Organizer
+###
+### Lines that start with # are comments!
+
+###
+### BASIC CONFIG
+###
+
+### Path to your source and destination folders
+#SRC_FOLDER: "/Users/YOUR_USERNAME/Samples"
+#DEST_FOLDER: "/Users/YOUR_USERNAME/M8 Samples"
+
+# For Windows, comment out the above lines and uncomment these
+SRC_FOLDER: D:\Users\Rich\Documents\Downloads\Samples
+DEST_FOLDER: D:\Users\Rich\Documents\Downloads\M8 Samples
+
+### Set the path to FFMPEG
+#FFMPEG_PATH: "c:\usr\local\bin\ffmpeg"
+
+# For Windows, comment out the above lines and uncomment these
+FFMPEG_PATH: C:\ffmpeg-7.1.1\bin\ffmpeg
+
+###
+### PATH CLEANUP CONFIG
+###
+
+# Words that start with a "strike word" are removed from the path.
+# Use this to remove common folder names like "processed", "final edit", etc.
+STRIKE_WORDS:
+- final
+- sample
+- label
+- process
+- edit
+- pack
+- wav
+- construct
+- cpa
+- splice
+- export
+
+
+# "Split punctuation" is used to separate words.
+SPLIT_PUNCTUATION:
+- "_"
+- " "
+- "-"
+- "+"
+
+# "Fill punctuation" is removed.
+FILL_PUNCTUATION:
+- ","
+- "("
+- ")"
+- "'"
+- "#"
+
+# RH added to clean up some of the MMP and MusicRadar sample names
+# Picotracker uses 24 char filenames max
+DELETE_WORDS:
+- mmp
+- ep
+- ep1
+- ep2
+- ep3
+- ep4
+- loop
+- wet
+- dry
+- brk
+- processed
+- full
+- drums
+- trail
+- bb
+- am
+- ho
+- id
+- 00s
+- 70s
+- 80s
+- ap
+- bl
+- eb
+- df
+- mg
+- bbr
+- gc
+- rs
+- dam
+- ssf
+- one
+- shot
+- percussion
+- sketch
+
+# This character is used to separate words in the final path (e.g. "Some_Pack_Name")
+JOIN_SEP: "_"
+
+
+###
+### AUDIO CONFIG
+###
+
+# The list of audio file types to be formatted
+FILE_TYPES:
+- wav
+
+# The bit depth used for the processed audio file (16 bit recommended for the M8)
+TARGET_BIT_DEPTH: 16
+
+# RH added MONO: true for mono, else stereo. 
+# Picotracker can read stereo .wavs but only seems to output panned mono audio. MONO files load much faster
+MONO:
+- true
+
+# Whether or not to reprocess audio files every time - useful if you've changed bit rate
+SKIP_EXISTING: true

--- a/src/m8-sample-organizer.py
+++ b/src/m8-sample-organizer.py
@@ -17,8 +17,10 @@ FILE_TYPES = config["FILE_TYPES"]
 SPLIT_PUNCTUATION = config["SPLIT_PUNCTUATION"]
 FILL_PUNCTUATION = config["FILL_PUNCTUATION"]
 STRIKE_WORDS = [word.lower() for word in config["STRIKE_WORDS"]]
+DELETE_WORDS = [word.lower() for word in config["DELETE_WORDS"]]
 JOIN_SEP = config["JOIN_SEP"]
 SKIP_EXISTING = config["SKIP_EXISTING"]
+MONO = config["MONO"]
 
 
 def get_files_by_type(folder, file_types=None):
@@ -108,6 +110,8 @@ def clean_file(file, unique_words):
     filename = " ".join(parts)
 
     words = filename.split()
+        # RH Remove any delete words
+    words = [word for word in words if word.lower() not in DELETE_WORDS]
 
     words = [capitalize(word) for word in words]
 
@@ -121,6 +125,8 @@ def remove_dupe_words(words, unique_words):
 
     # Remove any strike words
     words = [word for word in words if not any(word.lower().startswith(prefix) for prefix in STRIKE_WORDS)]
+
+
 
     # Add the remaining words to the set of unique words
     unique_words.update([word.lower() for word in words])
@@ -147,8 +153,12 @@ def convert_wav_to_16bit(ffmpeg_path, input_path, output_path):
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
 
     # Construct the FFmpeg command
-    command = [ffmpeg_path, '-hide_banner', '-loglevel', 'error', '-y', '-i', input_path, '-acodec', 'pcm_s16le', output_path]
-
+    # FOR MONO OUTPUT
+    if MONO:
+        command = [ffmpeg_path, '-hide_banner', '-loglevel', 'error', '-y', '-i', input_path, '-acodec', 'pcm_s16le','-ac', '1', output_path]
+    else:
+        command = [ffmpeg_path, '-hide_banner', '-loglevel', 'error', '-y', '-i', input_path, '-acodec', 'pcm_s16le', output_path]
+    
     try:
         subprocess.run(command, check=True)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
The config file now has a "DELETE_WORDS" section - any "DELETE_WORDS" will be stripped from the filename. This is helpful for reducing filenames to 24 characters as required by the PicoTracker. There is also a "MONO" option - if true will generate mono output files for faster load times.